### PR TITLE
don't require Path::Class unless necessary

### DIFF
--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -218,7 +218,7 @@ sub register_prereqs {
 		},
 		'Alien::Base' => '0.002',
 		'File::ShareDir' => '1.03',
-		'Path::Class' => '0.013',
+		@{ $self->split_bins } > 0 ? ('Path::Class' => '0.013') : (),
 	);
 	$self->zilla->register_prereqs({
 			type  => 'requires',
@@ -226,7 +226,7 @@ sub register_prereqs {
 		},
 		'Alien::Base' => '0.002',
 		'File::ShareDir' => '1.03',
-		'Path::Class' => '0.013',
+		@{ $self->split_bins } > 0 ? ('Path::Class' => '0.013') : (),
 	);
 }
 


### PR DESCRIPTION
This patch changes `[Alien]` so that it only adds the dep on `Path::Class` if it is necessary.  I believe this is okay because the `gather_files` happens before `register_prereqs`.

I am a fan of `Path::Class`, but I was surprised that my Alien dist depended on it, even though it wasn't using it.  I can remove the dep in my `dist.ini`, but I don't think it should be there in the first place.

Thanks, I appreciate your consideration.
