### PR TITLE
Features for Alien::Base 0.027

### DIFF
--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -399,7 +399,6 @@ sub register_prereqs {
 	my ( $self ) = @_;
 
 	my $ab_version = '0.002';
-	my $configure_requires = {};
 
 	if(defined $self->isolate_dynamic || defined $self->autoconf_with_pic || grep /(?<!\%)\%c/, @{ $self->build_command || [] }) {
 		$ab_version = '0.005';
@@ -407,9 +406,6 @@ sub register_prereqs {
 
 	if(@{ $self->inline_auto_include } || @{ $self->bin_requires } || defined $self->msys) {
 		$ab_version = '0.006';
-		if(@{ $self->bin_requires }) {
-			$configure_requires = $self->_bin_requires_hash;
-		}
 	}
 	
 	if(defined $self->stage_install) {
@@ -431,7 +427,6 @@ sub register_prereqs {
 		'Alien::Base::ModuleBuild' => $ab_version,
 		'File::ShareDir' => '1.03',
 		@{ $self->split_bins } > 0 ? ('Path::Class' => '0.013') : (),
-		%$configure_requires,
 	);
 	$self->zilla->register_prereqs({
 			type  => 'requires',

--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -393,6 +393,10 @@ sub register_prereqs {
 		$ab_version = '0.020';
 	}
 
+	if(grep /(?<!\%)\%X/, @{ $self->build_command || [] }, @{ $self->install_command || [] }, @{ $self->test_command || [] } ) {
+		$ab_version = '0.027';
+	}
+
 	$self->zilla->register_prereqs({
 			type  => 'requires',
 			phase => 'configure',

--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -191,8 +191,22 @@ are interpolated, and allow variables and helpers.
  env = PATH = /extra/path%{path}
  ; sets FOO to 1
  env = FOO = 1
- ; sets BAR to ''
- env = BAR
+
+There is no default value, so this is illegal:
+
+ [Alien]
+ ; won't build!
+ env = FOO
+
+Note that setting an environment variable to the empty string (C<''>) is not
+portable.  In particular it will work on Unix as you might expect, but in
+Windows it will actually unset the environment variable, which may not be
+what you intend.
+
+ [Alien]
+ ; works but not consistent
+ ; over all platforms
+ env = FOO =
 
 =head1 InstallRelease
 
@@ -365,7 +379,11 @@ has env => (
 
 sub _env_hash {
 	my($self) = @_;
-	my %env = map { /^\s*(.*?)\s*=\s*(.*)\s*$/ ? ($1 => $2) : ($_ => '') } @{ $self->env };
+	my %env = map {
+	  /^\s*(.*?)\s*=\s*(.*)\s*$/ 
+	    ? ($1 => $2) 
+	    : $self->log_fatal("Please specify a value for $_")
+	  } @{ $self->env };
 	\%env;
 }
 

--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -100,6 +100,13 @@ C<alien_install_commands> option). This is optional.
 
   install_command = make install
 
+=head2 test_command
+
+The ordered sequence of commands used to test the distribution (passed to the
+C<alien_test_commands> option).  This is optional, and not often used.
+
+  test_command = make check
+
 =head2 isolate_dynamic
 
 If set to true, then dynamic libraries will be isolated from the static libraries
@@ -285,6 +292,11 @@ has install_command => (
 	is => 'rw',
 );
 
+has test_command => (
+	isa => 'ArrayRef[Str]',
+	is => 'rw',
+);
+
 has isolate_dynamic => (
 	isa => 'Int',
 	is => 'rw',
@@ -353,7 +365,7 @@ has version_check => (
 # multiple build/install commands return as an arrayref
 around mvp_multivalue_args => sub {
   my ($orig, $self) = @_;
-  return ($self->$orig, 'build_command', 'install_command', 'inline_auto_include', 'bin_requires', 'helper');
+  return ($self->$orig, 'build_command', 'install_command', 'test_command', 'inline_auto_include', 'bin_requires', 'helper');
 };
 
 sub register_prereqs {
@@ -377,7 +389,7 @@ sub register_prereqs {
 		$ab_version = '0.016';
 	}
 	
-	if(@{ $self->helper } || grep /(?<!\%)\%\{([a-zA-Z_][a-zA-Z_0-9]+)\}/, @{ $self->build_command || [] }, @{ $self->install_command || [] } ) {
+	if(@{ $self->helper } || grep /(?<!\%)\%\{([a-zA-Z_][a-zA-Z_0-9]+)\}/, @{ $self->build_command || [] }, @{ $self->install_command || [] }, @{ $self->test_command || [] } ) {
 		$ab_version = '0.020';
 	}
 
@@ -475,6 +487,7 @@ around module_build_args => sub {
 		},
 		(alien_build_commands => $self->build_command)x!! $self->build_command,
 		(alien_install_commands => $self->install_command)x!! $self->install_command,
+		(alien_test_commands => $self->test_command)x!! $self->test_command,
 		(alien_inline_auto_include => $self->inline_auto_include)x!! $self->inline_auto_include,
 		defined $self->autoconf_with_pic ? (alien_autoconf_with_pic => $self->autoconf_with_pic) : (),
 		defined $self->isolate_dynamic ? (alien_isolate_dynamic => $self->isolate_dynamic) : (),

--- a/lib/Dist/Zilla/PluginBundle/Alien.pm
+++ b/lib/Dist/Zilla/PluginBundle/Alien.pm
@@ -3,6 +3,7 @@ package Dist::Zilla::PluginBundle::Alien;
 
 use Moose;
 use Dist::Zilla;
+use Dist::Zilla::Plugin::Alien;
 with 'Dist::Zilla::Role::PluginBundle::Easy';
 
 =head1 SYNOPSIS
@@ -22,6 +23,11 @@ with L<Dist::Zilla::PluginBundle::Basic>.
 =cut
 
 use Dist::Zilla::PluginBundle::Basic;
+
+# multiple build/install commands return as an arrayref
+sub mvp_multivalue_args {
+  Dist::Zilla::Plugin::Alien->mvp_multivalue_args;
+};
 
 sub configure {
   my ($self) = @_;

--- a/t/bin_requires.t
+++ b/t/bin_requires.t
@@ -28,8 +28,6 @@ subtest 'bin_requires' => sub {
   is $plugin->module_build_args->{alien_bin_requires}->{"Alien::bar"}, '2.0', "Alien::bar = 2.0";
   is $tzil->prereqs->as_string_hash->{runtime}->{requires}->{'Alien::Base'}, '0.006', 'configure prereq';
   is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::Base::ModuleBuild'}, '0.006', 'configure prereq';
-  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::foo'}, '0', 'configure prereq';
-  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::bar'}, '2.0', 'configure prereq';
   is $tzil->distmeta->{dynamic_config}, 1, 'dynamic_config';
 };
 

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+
+subtest 'build_command' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ '@Alien' => {
+            repo => 'http://localhost/foo/bar',
+            exact_filename => 'foo.tar.gz',
+            build_command => ['foo', 'bar'],
+            test_command => ['bar','baz'],
+            install_command => ['foo', 'baz'],
+          } ],
+        ),
+      },
+    }
+  );
+
+  $tzil->build;
+
+  my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
+  
+  ok $plugin, '[@Alien] adds [Alien]';
+
+  is_deeply $plugin->module_build_args->{alien_repository}, { protocol => 'http', host => 'localhost', location => '/foo/bar', exact_filename => 'foo.tar.gz' }, 'alien_repository';
+  is_deeply $plugin->module_build_args->{alien_build_commands}, [qw( foo bar )], 'build commands = foo bar';
+  is_deeply $plugin->module_build_args->{alien_test_commands}, [qw( bar baz )], 'test commands = bar baz';
+  is_deeply $plugin->module_build_args->{alien_install_commands}, [qw( foo baz )], 'install commands = foo baz';
+};
+
+done_testing;

--- a/t/command.t
+++ b/t/command.t
@@ -1,0 +1,78 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+
+subtest 'build_command' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ 'Alien' => {
+            repo => 'http://localhost/foo/bar',
+            build_command => [ 'foo', 'bar', 'baz' ],
+          } ],
+        ),
+      },
+    }
+  );
+
+  $tzil->build;
+
+  my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
+
+  is_deeply $plugin->module_build_args->{alien_build_commands}, [qw( foo bar baz )];
+};
+
+subtest 'install_command' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ 'Alien' => {
+            repo => 'http://localhost/foo/bar',
+            install_command => [ 'foo', 'bar', 'baz' ],
+          } ],
+        ),
+      },
+    }
+  );
+
+  $tzil->build;
+
+  my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
+
+  is_deeply $plugin->module_build_args->{alien_install_commands}, [qw( foo bar baz )];
+};
+
+subtest 'test_command' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ 'Alien' => {
+            repo => 'http://localhost/foo/bar',
+            test_command => [ 'foo', 'bar', 'baz' ],
+          } ],
+        ),
+      },
+    }
+  );
+
+  $tzil->build;
+
+  my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
+
+  is_deeply $plugin->module_build_args->{alien_test_commands}, [qw( foo bar baz )];
+};
+
+done_testing;

--- a/t/command.t
+++ b/t/command.t
@@ -75,4 +75,28 @@ subtest 'test_command' => sub {
   is_deeply $plugin->module_build_args->{alien_test_commands}, [qw( foo bar baz )];
 };
 
+subtest 'build_command' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ 'Alien' => {
+            repo => 'http://localhost/foo/bar',
+            build_command => [ '%X' ],
+          } ],
+        ),
+      },
+    }
+  );
+
+  $tzil->build;
+
+  my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
+
+  is_deeply $plugin->module_build_args->{requires}->{"Alien::Base"}, '0.027';
+  is_deeply $plugin->module_build_args->{configure_requires}->{"Alien::Base::ModuleBuild"}, '0.027';
+};
 done_testing;

--- a/t/env.t
+++ b/t/env.t
@@ -13,7 +13,7 @@ subtest 'simple' => sub {
           {},
           [ 'Alien' => {
             repo => 'http://localhost/foo/bar',
-            env => [ "FOO", "BAR = 1" ],
+            env => [ "BAR = 1" ],
           } ],
         ),
       },
@@ -24,7 +24,7 @@ subtest 'simple' => sub {
 
   my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
 
-  is_deeply $plugin->module_build_args->{alien_env}, { FOO => '', BAR => '1' };
+  is_deeply $plugin->module_build_args->{alien_env}, { BAR => '1' };
   is_deeply $plugin->module_build_args->{requires}->{"Alien::Base"}, '0.027';
   is_deeply $plugin->module_build_args->{configure_requires}->{"Alien::Base::ModuleBuild"}, '0.027';
 };

--- a/t/env.t
+++ b/t/env.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+
+subtest 'simple' => sub {
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          {},
+          [ 'Alien' => {
+            repo => 'http://localhost/foo/bar',
+            env => [ "FOO", "BAR = 1" ],
+          } ],
+        ),
+      },
+    }
+  );
+
+  $tzil->build;
+
+  my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
+
+  is_deeply $plugin->module_build_args->{alien_env}, { FOO => '', BAR => '1' };
+  is_deeply $plugin->module_build_args->{requires}->{"Alien::Base"}, '0.027';
+  is_deeply $plugin->module_build_args->{configure_requires}->{"Alien::Base::ModuleBuild"}, '0.027';
+};
+
+done_testing;


### PR DESCRIPTION
This adds support, and detection for the upcoming Alien::Base 0.027 release.  Also included is support for alien_test_commands which has been around forever, but not documented until recently.  Also the `[@Alien]` bundle was not correctly setting which values should be mvp, which is fixed in this PR.

This should not be merged until https://github.com/Perl5-Alien/Alien-Base/pull/152 is accepted.  Failing any dissent it will be accepted early next week.

I would like to have an `Alien::Base` and `Dist::Zilla::Plugin::Alien` release at about the same time (hopefully next week) and plan to blog about it on blogs.perl.org once it is available.  Having authored many Alien dists I think the plugin really is the best way to manage an Alien module as it doesn't require esoteric knowledge of feature history of `Alien::Base`.  It does, however, require vigilance in making sure the plugin is kept in sync feature wise with `Alien::Base`. 